### PR TITLE
Refactor error handling.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,46 +4,45 @@ const axios = require('axios');
 
 // Trigger the PagerDuty webhook with a given alert
 async function sendAlert(alert) {
-  try {
-    const response = await axios.post('https://events.pagerduty.com/v2/enqueue', alert);
+  const response = await axios.post('https://events.pagerduty.com/v2/enqueue', alert);
 
-    if (response.status === 202) {
-      console.log(`Successfully sent PagerDuty alert. Response: ${JSON.stringify(response.data)}`);
-    } else {
-      core.setFailed(
-        `PagerDuty API returned status code ${response.status} - ${JSON.stringify(response.data)}`
-      );
-    }
-  } catch (error) {
-    core.setFailed(error.message);
+  if (response.status === 202) {
+    console.log(`Successfully sent PagerDuty alert. Response: ${JSON.stringify(response.data)}`);
+  } else {
+    core.setFailed(
+      `PagerDuty API returned status code ${response.status} - ${JSON.stringify(response.data)}`
+    );
   }
 }
 
 // Run the action
-try {
-  const integrationKey = core.getInput('pagerduty-integration-key');
+(async () => {
+  try {
+    const integrationKey = core.getInput('pagerduty-integration-key');
 
-  let alert = {
-    payload: {
-      summary: `${context.repo.repo}: Error in "${context.workflow}" run by @${context.actor}`,
-      timestamp: new Date().toISOString(),
-      source: 'GitHub Actions',
-      severity: 'critical',
-      custom_details: {
-        run_details: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-        related_commits: context.payload.commits
-          ? context.payload.commits.map((commit) => `${commit.message}: ${commit.url}`).join(', ')
-          : 'No related commits',
+    let alert = {
+      payload: {
+        summary: `${context.repo.repo}: Error in "${context.workflow}" run by @${context.actor}`,
+        timestamp: new Date().toISOString(),
+        source: 'GitHub Actions',
+        severity: 'critical',
+        custom_details: {
+          run_details: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+          related_commits: context.payload.commits
+            ? context.payload.commits.map((commit) => `${commit.message}: ${commit.url}`).join(', ')
+            : 'No related commits',
+        },
       },
-    },
-    routing_key: integrationKey,
-    event_action: 'trigger',
-  };
-  const dedupKey = core.getInput('pagerduty-dedup-key');
-  if (dedupKey != '') {
-    alert.dedup_key = dedupKey;
+      routing_key: integrationKey,
+      event_action: 'trigger',
+    };
+    const dedupKey = core.getInput('pagerduty-dedup-key');
+    if (dedupKey != '') {
+      alert.dedup_key = dedupKey;
+    }
+    await sendAlert(alert);
+  } catch (error) {
+    core.setFailed(error.message);
   }
-  sendAlert(alert);
-} catch (error) {
-  core.setFailed(error.message);
-}
+})();
+


### PR DESCRIPTION
The async `sendAlert()` function call on L46 does not work as intended with the `try/catch` block that surrounds it.  I believe this inspired the additional `try/catch` block inside `sendAlert` itself.

https://github.com/Entle/action-pagerduty-alert/blob/main/index.js#L46

This PR is one possible remedy to this redundant code.