### PR TITLE
Replace deprecated action node12 with node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: 'The key used to correlate PagerDuty triggers, acknowledges, and resolves for the same alert.'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'
 branding:
   icon: 'alert-triangle'


### PR DESCRIPTION
While testing out this action I received a deprecation warning to upgrade to `node16`. This PR performs that upgrade.