### PR TITLE
Allow alerts to be resolved with a new argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Adding this to your `steps` will page if the job fails:
 ```yaml
 - name: Send PagerDuty alert on failure
   if: ${{ failure() }}
-  uses: Entle/action-pagerduty-alert@0.2.0
+  uses: Entle/action-pagerduty-alert@0.3.0
   with:
     pagerduty-integration-key: '${{ secrets.PAGERDUTY_INTEGRATION_KEY }}'
     pagerduty-dedup-key: github_workflow_failed
@@ -41,9 +41,9 @@ Adding this to your `steps` will page if the job fails:
 This config will resolve the page if the job subsequently succeeds:
 
 ```yaml
-- name: Send PagerDuty alert on failure
+- name: Resolve PagerDuty alert on success
   if: ${{ !failure() }}
-  uses: Entle/action-pagerduty-alert@0.2.0
+  uses: Entle/action-pagerduty-alert@0.3.0
   with:
     pagerduty-integration-key: '${{ secrets.PAGERDUTY_INTEGRATION_KEY }}'
     pagerduty-dedup-key: github_workflow_failed

--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ This config will resolve the page if the job subsequently succeeds:
     resolve: true
 ```
 
-Customizing the logic within the `if` configs allows for more complex page and resolution behavior.
+Adding both steps to your job will create an alert when the job fails, and resolve the job when it succeeds. Using `${{ github.workflow }}` for `pagerduty-dedup-key` (or any other key that is unique per-workflow) allows multiple jobs that each trigger and resolve alerts independently, while customizing the logic within the `if` configs allows for more complex page and resolution behavior.

--- a/README.md
+++ b/README.md
@@ -18,11 +18,16 @@ Sends a critical PagerDuty alert, e.g. on action failure.
 `pagerduty-dedup-key`
 
 **Optional:** a `dedup_key` for your alert. This will enable PagerDuty to coalesce multiple alerts into one.
+
+`resolve`
+
+**Optional:** If set to true, will resolve any active alerts with `dedup_key`. This allows you to automatically resolve alerts for a job if a subsequent run is successful.
+
 More documentation is available [here](https://developer.pagerduty.com/docs/events-api-v2/trigger-events/).
 
 ## Example usage
 
-In your `steps`:
+Adding this to your `steps` will page if the job fails:
 
 ```yaml
 - name: Send PagerDuty alert on failure
@@ -32,3 +37,17 @@ In your `steps`:
     pagerduty-integration-key: '${{ secrets.PAGERDUTY_INTEGRATION_KEY }}'
     pagerduty-dedup-key: github_workflow_failed
 ```
+
+This config will resolve the page if the job subsequently succeeds:
+
+```yaml
+- name: Send PagerDuty alert on failure
+  if: ${{ !failure() }}
+  uses: Entle/action-pagerduty-alert@0.2.0
+  with:
+    pagerduty-integration-key: '${{ secrets.PAGERDUTY_INTEGRATION_KEY }}'
+    pagerduty-dedup-key: github_workflow_failed
+    resolve: true
+```
+
+Customizing the logic within the `if` configs allows for more complex page and resolution behavior.

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   pagerduty-dedup-key:
     description: 'The key used to correlate PagerDuty triggers, acknowledges, and resolves for the same alert.'
     required: false
+  resolve:
+    description: 'If set to true, will resolve any alert with the same pagerduty-dedup-key (if such an alert exists).'
+    required: false
 runs:
   using: 'node12'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -43,6 +43,10 @@ try {
   if (dedupKey != '') {
     alert.dedup_key = dedupKey;
   }
+  const shouldResolve = core.getInput('resolve');
+  if (shouldResolve == 'true') {
+    alert.event_action = 'resolve';
+  }
   sendAlert(alert);
 } catch (error) {
   core.setFailed(error.message);


### PR DESCRIPTION
This change enables workflows which page on failure and auto-resolve on success. For example, you could have a job that deploys changes with some tests that are run post-deploy; this PR allows a second invocation of this action (with `resolve`), running on success, to resolve the page if the invocation is successful.

The docs are also updated with a usage example; I took the liberty of bumping the version of this action to 0.3.0 there.