### PR TITLE
add runbook url to pagerduty custom information

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Sends a critical PagerDuty alert, e.g. on action failure.
 
 **Required:** the integration key for your PagerDuty service
 
+`runbook-url`
+
+**Required:** the URL to a runbook to help triage the failure.
+
 `pagerduty-dedup-key`
 
 **Optional:** a `dedup_key` for your alert. This will enable PagerDuty to coalesce multiple alerts into one.

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   pagerduty-integration-key:
     description: 'The integration key for your PagerDuty service'
     required: true
+  runbook-url:
+    description: 'The URL of the runbook associated with this alert'
+    required: true
   pagerduty-dedup-key:
     description: 'The key used to correlate PagerDuty triggers, acknowledges, and resolves for the same alert.'
     required: false

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ try {
         related_commits: context.payload.commits
           ? context.payload.commits.map((commit) => `${commit.message}: ${commit.url}`).join(', ')
           : 'No related commits',
+        runbook: core.getInput('runbook-url'),
       },
     },
     routing_key: integrationKey,


### PR DESCRIPTION
So the on-call team knows where to find information about the service they are supposed to repair.