### PR TITLE
Update example to only resolve alert if workflow was not cancelled

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Optionally, add the below step after the one above to resolve the alert if a sub
 
 ```yaml
 - name: Resolve PagerDuty alert on success
-  if: ${{ !failure() }}
+  if: ${{ !failure() && !cancelled() }}
   uses: Entle/action-pagerduty-alert@1.0.2
   with:
     pagerduty-integration-key: '${{ secrets.PAGERDUTY_INTEGRATION_KEY }}'


### PR DESCRIPTION
Otherwise the alert may be prematurely resolved if someone manually cancels the workflow.