### PR TITLE
Added missing core import in send-alert

### DIFF
--- a/lib/send-alert.js
+++ b/lib/send-alert.js
@@ -1,3 +1,5 @@
+import core from '@actions/core';
+
 /**
  * Trigger a PagerDuty alert with the given alert object
  *


### PR DESCRIPTION
API errors resulted in `core is not defined` instead of bubbling up the API error